### PR TITLE
Add travis-ci integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: go
+
+go:
+  - "1.11"
+  - master
+
+script:
+  - make test

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,16 @@
+.DEFAULT_GOAL := build
+
+# Build app
 build:
 	go build
+.PHONY: build
 
+# Install app
 install:
 	go install
+.PHONY: install
+
+# Run tests
+test:
+	@go test -v -race $(shell go list ./...)
+.PHONY: test

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # riffraff
 
+[![Travis (.org)](https://img.shields.io/travis/mre/riffraff/master.svg?style=flat-square)](https://travis-ci.org/mre/riffraff)
+
 ![usage](usage.gif)
 
 A commandline interface for Jenkins jobs, which queries the current status of all matching jobs in parallel.


### PR DESCRIPTION
In order to run tests automatically, the travis-ci file for running
tests.

Inside the readme contains the info about travis build.

Relates: #2 
