### PR TITLE
Update the string used to print node status

### DIFF
--- a/internal/commands/logs.go
+++ b/internal/commands/logs.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/bndr/gojenkins"
-	"github.com/fatih/color"
 )
 
 type Logs struct {
@@ -19,9 +18,6 @@ func NewLogs(jenkins *gojenkins.Jenkins, jobName string, salt bool) *Logs {
 }
 
 func (l Logs) Exec() error {
-	yellow := color.New(color.FgYellow).SprintFunc()
-	red := color.New(color.FgRed).SprintFunc()
-	green := color.New(color.FgGreen).SprintFunc()
 
 	build, err := l.jenkins.GetJob(l.jobName)
 	if err != nil {
@@ -39,11 +35,11 @@ func (l Logs) Exec() error {
 	var marker string
 	switch result {
 	case "SUCCESS":
-		marker = green("✓")
+		marker = Good
 	case "FAILURE":
-		marker = red("✗")
+		marker = Bad
 	default:
-		marker = yellow("?")
+		marker = Unknown
 	}
 
 	fmt.Printf("%v %v (%v)\n", marker, l.jobName, lastBuild.GetUrl())


### PR DESCRIPTION
More consistency between node and job status printing methods.

Closes https://github.com/mre/riffraff/issues/15